### PR TITLE
Allow dynamic screen resolution

### DIFF
--- a/src/common/Game.cpp
+++ b/src/common/Game.cpp
@@ -15,6 +15,9 @@
 #endif
 
 
+int App::screenWidth = 640;
+int App::screenHeight = 480;
+
 void ensureSettingsDir()
 {
     const std::string smwHome = GetHomeDirectory();

--- a/src/common/Game.h
+++ b/src/common/Game.h
@@ -7,7 +7,7 @@ void ensureSettingsDir();
 
 class App {
 public:
-    static constexpr int screenWidth = 640;
-    static constexpr int screenHeight = 480;
+    static int screenWidth;
+    static int screenHeight;
     static constexpr int menuTransparency = 72;
 };

--- a/src/common/ObjectBase.cpp
+++ b/src/common/ObjectBase.cpp
@@ -3,6 +3,7 @@
 #include "GlobalConstants.h"
 #include "map.h"
 #include "gfx/gfxSprite.h"
+#include "Game.h"
 
 extern CMap* g_map;
 
@@ -52,26 +53,26 @@ std::array<IO_Block*, 4> CObject::GetCollisionBlocks() const
 {
     short xl = 0;
     if (ix < 0)
-        xl = (ix + 640) / TILESIZE;
+        xl = (ix + App::screenWidth) / TILESIZE;
     else
         xl = ix / TILESIZE;
 
     short xr = 0;
-    if (ix + iw >= 640)
-        xr = (ix + iw - 640) / TILESIZE;
+    if (ix + iw >= App::screenWidth)
+        xr = (ix + iw - App::screenWidth) / TILESIZE;
     else
         xr = (ix + iw) / TILESIZE;
 
     std::array<IO_Block*, 4> blocks;
     blocks.fill(nullptr);
 
-    if (iy >= 0 && iy < 480) {
+    if (iy >= 0 && iy < App::screenHeight) {
         short yt = iy / TILESIZE;
         blocks[0] = g_map->block(xl, yt);
         blocks[1] = g_map->block(xr, yt);
     }
 
-    if (iy + ih >= 0 && iy + ih < 480) {
+    if (iy + ih >= 0 && iy + ih < App::screenHeight) {
         short yb = (iy + ih) / TILESIZE;
         blocks[2] = g_map->block(xl, yb);
         blocks[3] = g_map->block(xr, yb);

--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -2,6 +2,7 @@
 
 #include "gfx/Color.h"
 #include "gfx/gfxSDL.h"
+#include "Game.h"
 
 #include "SDL_image.h"
 #include "sdl12wrapper.h"
@@ -11,6 +12,7 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
+#include <cstdlib>
 
 using namespace std;
 
@@ -182,6 +184,18 @@ RGB getRgb(SDL_Surface* surf, int x, int y)
 
 
 bool gfx_init(int w, int h, bool fullscreen) {
+    const char* env_w = getenv("SMW_WIDTH");
+    const char* env_h = getenv("SMW_HEIGHT");
+    if (env_w)
+        w = atoi(env_w);
+    if (env_h)
+        h = atoi(env_h);
+
+    GFX_SCREEN_W = w;
+    GFX_SCREEN_H = h;
+    App::screenWidth = w;
+    App::screenHeight = h;
+
     return gfx.Init(fullscreen);
 }
 

--- a/src/common/gfx/gfxSDL.cpp
+++ b/src/common/gfx/gfxSDL.cpp
@@ -4,6 +4,7 @@
 
 #include "SDL.h"
 #include "SDL_image.h"
+#include "Game.h"
 
 #include <chrono>
 #include <iomanip>
@@ -14,8 +15,9 @@
 extern SDL_Surface* screen;
 
 #define GFX_BPP 16
-#define GFX_SCREEN_W 640
-#define GFX_SCREEN_H 480
+
+int GFX_SCREEN_W = 640;
+int GFX_SCREEN_H = 480;
 
 enum SDL_Errors {
     E_INIT_SDL,
@@ -39,6 +41,9 @@ GraphicsSDL::~GraphicsSDL() {
 
 bool GraphicsSDL::Init(bool fullscreen)
 {
+    App::screenWidth = GFX_SCREEN_W;
+    App::screenHeight = GFX_SCREEN_H;
+
     try {
         init_sdl();
         init_sdl_img();

--- a/src/common/gfx/gfxSDL.h
+++ b/src/common/gfx/gfxSDL.h
@@ -5,6 +5,9 @@
 
 #include "gfxPalette.h"
 
+extern int GFX_SCREEN_W;
+extern int GFX_SCREEN_H;
+
 class GraphicsSDL
 {
 public:

--- a/src/common/gfx/gfxSprite.cpp
+++ b/src/common/gfx/gfxSprite.cpp
@@ -1,6 +1,7 @@
 #include "gfxSprite.h"
 
 #include "gfx.h"
+#include "Game.h"
 
 #include "SDL_image.h"
 #include "sdl12wrapper.h"
@@ -19,7 +20,7 @@ extern short y_shake;
 gfxSprite::gfxSprite()
 {
     clearSurface();
-    iWrapSize = 640; // TODO: Get it from a global setting.
+    iWrapSize = App::screenWidth;
 }
 
 gfxSprite::~gfxSprite()

--- a/src/smw/player.cpp
+++ b/src/smw/player.cpp
@@ -23,6 +23,7 @@
 #include "objects/moving/MO_Hammer.h"
 #include "objects/moving/MO_IceBlast.h"
 #include "objects/moving/MO_Podobo.h"
+#include "Game.h"
 
 #include <cassert>
 #include <cmath>
@@ -2182,7 +2183,7 @@ bool CPlayer::mapcolldet_handleOutOfScreen()
         }
 
         return true;
-    } else if (fPrecalculatedY + PH >= 480) {
+    } else if (fPrecalculatedY + PH >= App::screenHeight) {
         //on ground outside of the screen?
         setYi(-PH);
         fOldY = (float)(-PH - 1);
@@ -2774,12 +2775,12 @@ void CPlayer::flipsidesifneeded()
     //Use ix here to avoid rounding issues (can crash if tile_x_right evals to over the right side of screen)
     if (ix < 0 || fx < 0.0f) {
         //This avoids rounding errors
-        setXf(fx + 640);
-        fOldX += 640;
+        setXf(fx + App::screenWidth);
+        fOldX += App::screenWidth;
         //printf("Flipped Left\n");
-    } else if (ix >= 640 || fx >= 640) {
-        setXf(fx - 640);
-        fOldX -= 640;
+    } else if (ix >= App::screenWidth || fx >= App::screenWidth) {
+        setXf(fx - App::screenWidth);
+        fOldX -= App::screenWidth;
         //printf("Flipped Right\n");
     }
 }

--- a/src/smw/player_components/PlayerCollisions.cpp
+++ b/src/smw/player_components/PlayerCollisions.cpp
@@ -6,6 +6,7 @@
 #include "map.h"
 #include "player.h"
 #include "ResourceManager.h"
+#include "Game.h"
 
 extern CMap* g_map;
 
@@ -28,8 +29,8 @@ bool PlayerCollisions::checktop(CPlayer& player)
         return false;
 
     short tile_x_right = -1;
-    if (player.rightX() >= 640)
-        tile_x_right = (player.rightX() - 640) / TILESIZE;
+    if (player.rightX() >= App::screenWidth)
+        tile_x_right = (player.rightX() - App::screenWidth) / TILESIZE;
     else
         tile_x_right = player.rightX() / TILESIZE;
 
@@ -104,8 +105,8 @@ bool PlayerCollisions::checkright(CPlayer& player)
 
     short tile_x = -1;
 
-    if (player.rightX() >= 640)
-        tile_x = (player.rightX() - 640) / TILESIZE;
+    if (player.rightX() >= App::screenWidth)
+        tile_x = (player.rightX() - App::screenWidth) / TILESIZE;
     else
         tile_x = player.rightX() / TILESIZE;
 
@@ -136,8 +137,8 @@ void PlayerCollisions::checksides(CPlayer& player)
     short tile_x_left = player.leftX() >> 5;
 
     short tile_x_right = -1;
-    if (player.rightX() >= 640)
-        tile_x_right = (player.rightX() - 640) >> 5;
+    if (player.rightX() >= App::screenWidth)
+        tile_x_right = (player.rightX() - App::screenWidth) >> 5;
     else
         tile_x_right = player.rightX() >> 5;
 


### PR DESCRIPTION
## Summary
- Replace hard-coded screen dimensions with global variables
- Read SMW_WIDTH/SMW_HEIGHT environment variables to configure resolution
- Propagate runtime screen size to collision and wrapping logic

## Testing
- `cmake -S . -B build` *(fails: Could NOT find SDL2)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2927c790832699d67c16fde72755